### PR TITLE
Fixed 'ConvertTo-Yaml'

### DIFF
--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -203,7 +203,7 @@ function ConvertTo-Yaml {
         $d.Add($data)
     }
     END {
-        if(!$d){
+        if($d -eq $null){
             return
         }
         $norm = Convert-PSObjectToGenericObject $d


### PR DESCRIPTION
We are not able to serialize the array `$a = @($false)` or variable `$a = $false` because function returns early.

Array case:
```
PS C:\Users\ibalutoiu> $a = @($false)
PS C:\Users\ibalutoiu> $a.Count
1
PS C:\Users\ibalutoiu> !$a
True
```