### PR TITLE
Support for int value as string

### DIFF
--- a/Tests/powershell-yaml.Tests.ps1
+++ b/Tests/powershell-yaml.Tests.ps1
@@ -210,12 +210,12 @@ bools:
                 int64 = ([int64]::MaxValue);
                 note = ("I can't wait. To get that Cool Book.`n");
                 dates = @(
-                            [DateTime]::Parse('2001-12-15T02:59:43.1Z'),
-                            [DateTime]::Parse('2001-12-14t21:59:43.10-05:00'),
-                            [DateTime]::Parse('2001-12-14 21:59:43.10 -5'),
-                            [DateTime]::Parse('2001-12-15 2:59:43.10'),
-                            [DateTime]::Parse('2002-12-14')
-                        );
+                    [DateTime]::Parse('2001-12-15T02:59:43.1Z'),
+                    [DateTime]::Parse('2001-12-14t21:59:43.10-05:00'),
+                    [DateTime]::Parse('2001-12-14 21:59:43.10 -5'),
+                    [DateTime]::Parse('2001-12-15 2:59:43.10'),
+                    [DateTime]::Parse('2002-12-14')
+                );
                 version = "1.2.3";
                 noniso8601dates = @( '5/4/2017', '1.2.3' );            
                 bools = @( $true, $false, $true, $false, $true, $false );
@@ -326,5 +326,67 @@ bools:
             }
         }
 
+    }
+    
+    Describe "Generic Casting Behaviour" {
+        Context "Node Style is 'Plain'" {
+            $value = @'
+ T1: 001
+'@
+            It 'Should be an int' {
+                $result = ConvertFrom-Yaml -Yaml $value
+                $result.T1 | Should BeOfType System.Int32
+            }
+            
+            It 'Should be value of 1' {
+                $result = ConvertFrom-Yaml -Yaml $value
+                $result.T1 | Should Be 1
+            }
+            
+            It 'Should not be value of 001' {
+                $result = ConvertFrom-Yaml -Yaml $value
+                $result.T1 | Should Not Be '001'
+            }
+        }
+        
+        Context "Node Style is 'SingleQuoted'" {
+            $value = @'
+ T1: '001'
+'@
+            It 'Should be a string' {
+                $result = ConvertFrom-Yaml -Yaml $value
+                $result.T1 | Should BeOfType System.String
+            }
+            
+            It 'Should be value of 001' {
+                $result = ConvertFrom-Yaml -Yaml $value
+                $result.T1 | Should Be '001'
+            }
+            
+            It 'Should not be value of 1' {
+                $result = ConvertFrom-Yaml -Yaml $value
+                $result.T1 | Should Not Be '1'
+            }
+        }
+        
+        Context "Node Style is 'DoubleQuoted'" {
+            $value = @'
+ T1: "001"
+'@
+            It 'Should be a string' {
+                $result = ConvertFrom-Yaml -Yaml $value
+                $result.T1 | Should BeOfType System.String
+            }
+            
+            It 'Should be value of 001' {
+                $result = ConvertFrom-Yaml -Yaml $value
+                $result.T1 | Should Be '001'
+            }
+            
+            It 'Should not be value of 1' {
+                $result = ConvertFrom-Yaml -Yaml $value
+                $result.T1 | Should Not Be '1'
+            }
+        }
     }
 }

--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -131,7 +131,7 @@ function Convert-YamlDocumentToPSObject {
                 return Convert-YamlSequenceToArray $Node
             }
             "YamlDotNet.RepresentationModel.YamlScalarNode" {
-                return (Convert-ValueToProperType $Node.Value)
+                return (Convert-ValueToProperType $Node)
             }
         }
     }

--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -39,25 +39,28 @@ function Convert-ValueToProperType {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
-        [System.Object]$Value
+        [System.Object]$Node
     )
     PROCESS {
-        if (!($Value -is [string])) {
-            return $Value
+        if (!($Node.Value -is [string])) {
+            return $Node
         }
-        $types = @([int], [long], [double], [boolean], [decimal])
-        foreach($i in $types){
-            $parsedValue = New-Object -TypeName $i.FullName
-            if ($i.IsAssignableFrom([boolean])){
-                $result = $i::TryParse($Value,[ref]$parsedValue) 
-            } else {
-                $result = $i::TryParse($Value, [Globalization.NumberStyles]::Any, [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)
-            }
-            if( $result ) {
-                return $parsedValue
+        
+        if ($Node.Style -eq 'Plain')
+        {
+            $types = @([int], [long], [double], [boolean], [decimal])
+            foreach($i in $types){
+                $parsedValue = New-Object -TypeName $i.FullName
+                if ($i.IsAssignableFrom([boolean])){
+                    $result = $i::TryParse($Node,[ref]$parsedValue) 
+                } else {
+                    $result = $i::TryParse($Node, [Globalization.NumberStyles]::Any, [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)
+                }
+                if( $result ) {
+                    return $parsedValue
+                }
             }
         }
-
         # From the YAML spec: http://yaml.org/type/timestamp.html
         $regex = @'
 [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] # (ymd)
@@ -70,14 +73,14 @@ function Convert-ValueToProperType {
  (\.[0-9]*)? # (fraction)
  (([ \t]*)Z|[-+][0-9][0-9]?(:[0-9][0-9])?)? # (time zone)
 '@
-        if( [Text.RegularExpressions.Regex]::IsMatch($Value, $regex, [Text.RegularExpressions.RegexOptions]::IgnorePatternWhitespace) ) {
+        if([Text.RegularExpressions.Regex]::IsMatch($Node.Value, $regex, [Text.RegularExpressions.RegexOptions]::IgnorePatternWhitespace) ) {
             [DateTime]$datetime = [DateTime]::MinValue
-            if( ([DateTime]::TryParse($Value,[ref]$datetime)) ) {
+            if( ([DateTime]::TryParse($Node.Value,[ref]$datetime)) ) {
                 return $datetime
             }
         }
             
-        return $Value
+        return $Node.Value
     }
 }
 


### PR DESCRIPTION
Thanks for providing this great module. We need a way to store integer values with leading zeroes and so far all zeroes are removed by how Convert-ValueToProperType tries to cast values. I would like to propose only trying the cast if the node style is 'Plain'.

After the change the following block
```
T1: "001"
T2: '001'
T3: 001
```
results in

```
Name                           Value                                                                                        
----                           -----                                                                                        
T1                             001                                                                                          
T2                             001                                                                                          
T3                             1   
```
