### PR TITLE
ConvertTo-Yaml without tags

### DIFF
--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -235,14 +235,17 @@ function ConvertFrom-Yaml {
     }
 }
 
+
 function ConvertTo-Yaml {
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory=$false,ValueFromPipeline=$true)]
+        [Parameter(ValueFromPipeline=$true)]
         [System.Object]$Data,
-        [Parameter(Mandatory=$false)]
+        
         [string]$OutFile,
-        [switch]$JsonCompatible=$false,
+        
+        [YamlDotNet.Serialization.SerializationOptions]$Options = [YamlDotNet.Serialization.SerializationOptions]::Roundtrip,
+        
         [switch]$Force=$false
     )
     BEGIN {
@@ -274,15 +277,14 @@ function ConvertTo-Yaml {
             $wrt = New-Object "System.IO.StringWriter"
         }
 
-        $options = 0
-        if ($JsonCompatible) {
-            # No indent options :~(
-            $options = [YamlDotNet.Serialization.SerializationOptions]::JsonCompatible
-        }
         try {
             $serializer = New-Object "YamlDotNet.Serialization.Serializer" $options
             $serializer.Serialize($wrt, $norm)
-        } finally {
+        }
+        catch{
+            $_
+        } 
+        finally {
             $wrt.Close()
         }
         if($OutFile){

--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -237,16 +237,20 @@ function ConvertFrom-Yaml {
 
 
 function ConvertTo-Yaml {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'NoOptions')]
     Param(
-        [Parameter(ValueFromPipeline=$true)]
+        [Parameter(ValueFromPipeline = $true)]
         [System.Object]$Data,
-        
+
         [string]$OutFile,
-        
+
+        [Parameter(ParameterSetName = 'Options')]
         [YamlDotNet.Serialization.SerializationOptions]$Options = [YamlDotNet.Serialization.SerializationOptions]::Roundtrip,
-        
-        [switch]$Force=$false
+
+        [Parameter(ParameterSetName = 'NoOptions')]
+        [switch]$JsonCompatible,
+
+        [switch]$Force
     )
     BEGIN {
         $d = [System.Collections.Generic.List[object]](New-Object "System.Collections.Generic.List[object]")
@@ -257,19 +261,19 @@ function ConvertTo-Yaml {
         }
     }
     END {
-        if($d -eq $null -or $d.Count -eq 0){
+        if ($d -eq $null -or $d.Count -eq 0) {
             return
         }
-        if($d.Count -eq 1) {
+        if ($d.Count -eq 1) {
             $d = $d[0]
         }
         $norm = Convert-PSObjectToGenericObject $d
-        if($OutFile) {
+        if ($OutFile) {
             $parent = Split-Path $OutFile
-            if(!(Test-Path $parent)) {
+            if (!(Test-Path $parent)) {
                 Throw "Parent folder for specified path does not exist"
             }
-            if((Test-Path $OutFile) -and !$Force){
+            if ((Test-Path $OutFile) -and !$Force) {
                 Throw "Target file already exists. Use -Force to overwrite."
             }
             $wrt = New-Object "System.IO.StreamWriter" $OutFile
@@ -277,19 +281,28 @@ function ConvertTo-Yaml {
             $wrt = New-Object "System.IO.StringWriter"
         }
 
+        if ($PSCmdlet.ParameterSetName -eq 'NoOptions') {
+            $Options = 0
+
+            if ($JsonCompatible) {
+                # No indent options :~(
+                $options = [YamlDotNet.Serialization.SerializationOptions]::JsonCompatible
+            }
+        }
+
         try {
-            $serializer = New-Object "YamlDotNet.Serialization.Serializer" $options
+            $serializer = New-Object "YamlDotNet.Serialization.Serializer" $Options
             $serializer.Serialize($wrt, $norm)
         }
         catch{
             $_
-        } 
+        }
         finally {
             $wrt.Close()
         }
-        if($OutFile){
+        if ($OutFile) {
             return
-        }else {
+        } else {
             return $wrt.ToString()
         }
     }


### PR DESCRIPTION
We need to change yaml files that do not contain any type information. When converting the data back to yaml, it looks like this:

``` PowerShell
$h = @{
    k1 = 'v1'
    k2 = 'v2'
}
$h | ConvertTo-Yaml
```

```
!System.Collections.Hashtable,%20mscorlib,%20Version=4.0.0.0,%20Culture=neutral,%20PublicKeyToken=b77a5c561934e089
k1: v1
k2: v2
```


The change makes the serialization options accessible. Still the default is RoundTrip but the caller can choose directly, for example EmitDefaults or JsonCompatible. There is no need anymore to have a switch that just allows for JsonCompatible.

``` PowerShell
$h = @{
    k1 = 'v1'
    k2 = 'v2'
}
$h | ConvertTo-Yaml -Options EmitDefaults
```
```
k1: v1
k2: v2
```