### PR TITLE
Support nested ordered structures

### DIFF
--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -112,12 +112,13 @@ function Convert-YamlSequenceToArray {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        [YamlDotNet.RepresentationModel.YamlSequenceNode]$Node
+        [YamlDotNet.RepresentationModel.YamlSequenceNode]$Node,
+        [switch]$Ordered
     )
     PROCESS {
         $ret = [System.Collections.Generic.List[object]](New-Object "System.Collections.Generic.List[object]")
         foreach($i in $Node.Children){
-            $ret.Add((Convert-YamlDocumentToPSObject $i))
+            $ret.Add((Convert-YamlDocumentToPSObject $i -Ordered:$Ordered))
         }
         return ,$ret
     }
@@ -136,7 +137,7 @@ function Convert-YamlDocumentToPSObject {
                 return Convert-YamlMappingToHashtable $Node -Ordered:$Ordered
             }
             "YamlDotNet.RepresentationModel.YamlSequenceNode" {
-                return Convert-YamlSequenceToArray $Node
+                return Convert-YamlSequenceToArray $Node -Ordered:$Ordered
             }
             "YamlDotNet.RepresentationModel.YamlScalarNode" {
                 return (Convert-ValueToProperType $Node)


### PR DESCRIPTION
Hi,

I noticed the `-ordered` parameter at the moment does not support hashtables nested inside arrays. This PR should be fixing that by passing the parameter through the array processing function.
