### PR TITLE
Feature: Add -UseDeserializer to ConvertFrom-Yaml

### DIFF
--- a/Tests/Mocks/YamlInYMinutes.yaml
+++ b/Tests/Mocks/YamlInYMinutes.yaml
@@ -1,0 +1,148 @@
+---  # document start
+
+# Comments in YAML look like this.
+
+################
+# SCALAR TYPES #
+################
+
+# Our root object (which continues for the entire document) will be a map,
+# which is equivalent to a dictionary, hash or object in other languages.
+key: value
+another_key: Another value goes here.
+a_number_value: 100
+scientific_notation: 1e+12
+# The number 1 will be interpreted as a number, not a boolean. if you want
+# it to be interpreted as a boolean, use true
+boolean: true
+null_value: null
+key with spaces: value
+# Notice that strings don't need to be quoted. However, they can be.
+however: 'A string, enclosed in quotes.'
+'Keys can be quoted too.': "Useful if you want to put a ':' in your key."
+single quotes: 'have ''one'' escape pattern'
+double quotes: "have many: \", \0, \t, \u263A, \x0d\x0a == \r\n, and more."
+
+# Multiple-line strings can be written either as a 'literal block' (using |),
+# or a 'folded block' (using '>').
+literal_block: |
+    This entire block of text will be the value of the 'literal_block' key,
+    with line breaks being preserved.
+
+    The literal continues until de-dented, and the leading indentation is
+    stripped.
+
+        Any lines that are 'more-indented' keep the rest of their indentation -
+        these lines will be indented by 4 spaces.
+folded_style: >
+    This entire block of text will be the value of 'folded_style', but this
+    time, all newlines will be replaced with a single space.
+
+    Blank lines, like above, are converted to a newline character.
+
+        'More-indented' lines keep their newlines, too -
+        this text will appear over two lines.
+
+####################
+# COLLECTION TYPES #
+####################
+
+# Nesting uses indentation. 2 space indent is preferred (but not required).
+a_nested_map:
+  key: value
+  another_key: Another Value
+  another_nested_map:
+    hello: hello
+
+# Maps don't have to have string keys.
+0.25: a float key
+
+# Keys can also be complex, like multi-line objects
+# We use ? followed by a space to indicate the start of a complex key.
+? |
+  This is a key
+  that has multiple lines
+: and this is its value
+
+# YAML also allows mapping between sequences with the complex key syntax
+# Some language parsers might complain
+# An example
+? - Manchester United
+  - Real Madrid
+: [2001-01-01, 2002-02-02]
+
+# Sequences (equivalent to lists or arrays) look like this
+# (note that the '-' counts as indentation):
+a_sequence:
+  - Item 1
+  - Item 2
+  - 0.5  # sequences can contain disparate types.
+  - Item 4
+  - key: value
+    another_key: another_value
+  -
+    - This is a sequence
+    - inside another sequence
+  - - - Nested sequence indicators
+      - can be collapsed
+
+# Since YAML is a superset of JSON, you can also write JSON-style maps and
+# sequences:
+json_map: {"key": "value"}
+json_seq: [3, 2, 1, "takeoff"]
+and quotes are optional: {key: [3, 2, 1, takeoff]}
+
+#######################
+# EXTRA YAML FEATURES #
+#######################
+
+# YAML also has a handy feature called 'anchors', which let you easily duplicate
+# content across your document. Both of these keys will have the same value:
+anchored_content: &anchor_name This string will appear as the value of two keys.
+other_anchor: *anchor_name
+
+# Anchors can be used to duplicate/inherit properties
+base: &base
+  name: Everyone has same name
+
+# The regexp << is called Merge Key Language-Independent Type. It is used to
+# indicate that all the keys of one or more specified maps should be inserted
+# into the current map.
+
+foo: &foo
+  <<: *base
+  age: 10
+
+bar: &bar
+  <<: *foo
+  age: 20
+
+# foo and bar would also have name: Everyone has same name
+
+# YAML also has tags, which you can use to explicitly declare types.
+explicit_string: !!str 0.5
+
+####################
+# EXTRA YAML TYPES #
+####################
+
+# Strings and numbers aren't the only scalars that YAML can understand.
+# ISO-formatted date and datetime literals are also parsed.
+datetime: 2001-12-15T02:59:43.1Z
+datetime_with_spaces: 2001-12-14 21:59:43.10 -5
+date: 2002-12-14
+
+# YAML also has a set type, which looks like this:
+set:
+  ? item1
+  ? item2
+  ? item3
+or: {item1, item2, item3}
+
+# Sets are just maps with null values; the above is equivalent to:
+set2:
+  item1: null
+  item2: null
+  item3: null
+
+...  # document end

--- a/Tests/powershell-yaml.Tests.ps1
+++ b/Tests/powershell-yaml.Tests.ps1
@@ -17,7 +17,7 @@ $moduleHome = Split-Path -Parent $here
 
 $moduleName = "powershell-yaml"
 $modulePath = Join-Path $moduleHome "powershell-yaml.psd1"
-Import-Module $modulePath
+Import-Module $modulePath -force
 
 InModuleScope $moduleName {
 
@@ -82,10 +82,9 @@ InModuleScope $moduleName {
 
             foreach ($item in $items) {
 
-                It "Should represent identity to encode and decode." {
+                It "Should represent identity to encode and decode - $item" {
                     $yaml = ConvertTo-Yaml $item
                     $i = ConvertFrom-Yaml $yaml
-
                     $item -eq $i | Should Be $true
                 }
 
@@ -511,6 +510,25 @@ bools:
             It 'Should serialise with double quotes' {
                 $result = ConvertTo-Yaml $value
                 $result | Should Be "key: """"$([Environment]::NewLine)"
+            }
+        }
+    }
+
+    Describe "deserializeYaml" {
+        $SCRIPT:yamlInput = Get-Content -raw "$PSScriptRoot\Mocks\YamlInYMinutes.yaml"
+        Describe "DeserializeYaml" {
+            It "Should Deserialize YamlInYMinutes File" {
+                ConvertFrom-Yaml -UseDeserializer $yamlInput | Should -BeOfType [hashtable]
+            }
+
+            It "Should Merge Parser Merges Correctly" {
+                $result = ConvertFrom-Yaml -UseDeserializer -UseMergingParser $yamlInput
+                $result.foo.name | Should -Be "Everyone has same name"
+            }
+
+            It "Should Merge Parser Overrides Existing Value" {
+                $result = ConvertFrom-Yaml -UseDeserializer -UseMergingParser $yamlInput
+                $result.bar.age | Should -Be "20"
             }
         }
     }


### PR DESCRIPTION
This adds the deserializer parameter to ConvertFrom-Yaml as per the YamlDotNet samples as an alternative parsing mechanism to the YAML stream. The main reason for this is to support Merge Overwrites:

```powershell
@'
base: &base
  name: 'base'
  value: 1234

overwrite:
  <<: *base
  value: OVERRIDE4567
'@ | ConvertFrom-Yaml -UseMergingParser -UseDeserializer | % overwrite

Name                           Value
----                           -----
name                           base
value                          OVERRIDE4567
```

It also results in a 20x increase in performance:
```powershell
PS> measure-command {convertfrom-yaml $yamlinyminutes} | % totalmilliseconds
82.3287
PS> measure-command {convertfrom-yaml -UseDeserializer $yamlinyminutes} | % totalmilliseconds
4.0917
```

And also comes natively with .NET types that don't have to be interpreted. These can be seen using the -Raw parameter, but I convert the dictionaries to hashtables for easier use for Powershell users by default.

I added it as a parameter so as to remain backwards compatible with the existing implementation.

## Major Limitation
As of now the YamlDotNet parser doesn't support the default schema, so everything comes out as a string unless you tag your types in the yaml itself.