### PR TITLE
Added KeepArray switch to ConvertTo-Yaml

### DIFF
--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -353,6 +353,8 @@ function ConvertTo-Yaml {
 
         [Parameter(ParameterSetName = 'NoOptions')]
         [switch]$JsonCompatible,
+        
+        [switch]$KeepArray,
 
         [switch]$Force
     )
@@ -368,7 +370,7 @@ function ConvertTo-Yaml {
         if ($d -eq $null -or $d.Count -eq 0) {
             return
         }
-        if ($d.Count -eq 1) {
+        if ($d.Count -eq 1 -and !($KeepArray)) {
             $d = $d[0]
         }
         $norm = Convert-PSObjectToGenericObject $d


### PR DESCRIPTION
Some applications require the leading '-' even if there is only a single element. Added the KeepArray switch to give the option of not stripping the array to a single element.