### PR TITLE
Detect `YamlDotNet` availability by checking if type can be resolved instead

### DIFF
--- a/Load-Assemblies.ps1
+++ b/Load-Assemblies.ps1
@@ -42,11 +42,12 @@ function Initialize-Assemblies {
         "StaticTypeResolver"
     )
 
-    $yaml = [System.AppDomain]::CurrentDomain.GetAssemblies() | ? Location -Match "YamlDotNet.dll"
-    if (!$yaml) {
+    $type = "YamlDotNet.Serialization.Serializer" -as [type]
+    if (!$type) {
         return Load-Assembly
     }
 
+    $yaml = $type.Assembly
     foreach ($i in $requiredTypes){
         if ($i -notin $yaml.DefinedTypes.Name) {
             Throw "YamlDotNet is loaded but missing required types ($i). Older version installed on system?"


### PR DESCRIPTION
Detect `YamlDotNet` availability by checking if type can be resolved instead

`[System.AppDomain]::CurrentDomain.GetAssemblies()` returns all loaded assemblies in .NET, regardless of which `AssemblyLoadContext` they are from. However, in PowerShell, assemblies loaded in a custom `AssemblyLoadContext` are not considered discoverable -- they are supposed to be isolated from the default `AssemblyLoadContext` and resolving types from them could cause the conflicting type identity issue (the type "a.b" cannot be cast to "a.b", becasue they are from different assemblies that are loaded in different assembly load contexts).

Therefore, `[System.AppDomain]::CurrentDomain.GetAssemblies() | ? Location -Match "YamlDotNet.dll"` may return you a `YamlDotNet` assembly that was loaded into a custom `AssemblyLoadContext` by another module, and then later in `[powershell-yaml.psm1](https://github.com/cloudbase/powershell-yaml/blob/master/powershell-yaml.psm1)`, resolving the type `[YamlDotNet.Serialization.Serializer]` will fail.

So, it's safer to check the availability of `YamlDotNet` by checking if the string "YamlDotNet.Serialization.Serializer" can be resolved to a type.