### PR TITLE
Export functions and aliases

### DIFF
--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -429,4 +429,4 @@ function ConvertTo-Yaml {
 New-Alias -Name cfy -Value ConvertFrom-Yaml
 New-Alias -Name cty -Value ConvertTo-Yaml
 
-Export-ModuleMember -Function * -Alias *
+Export-ModuleMember -Function ConvertFrom-Yaml,ConvertTo-Yaml -Alias cfy,cty


### PR DESCRIPTION
Explicitly export desired function names and aliases without using *.

Fixes: #98