### PR TITLE
Default date conversions to UTC and RoundTripKind

### DIFF
--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -95,7 +95,9 @@ function Convert-ValueToProperType {
                 "tag:yaml.org,2002:timestamp" {
                     # From the YAML spec: http://yaml.org/type/timestamp.html
                     [DateTime]$parsedValue = [DateTime]::MinValue
-                    if(![DateTime]::TryParse($Node.Value,[ref]$parsedValue)) {
+                    $ts = [DateTime]::SpecifyKind($Node.Value, [System.DateTimeKind]::Utc)
+                    $tss = $ts.ToString("o")
+                    if(![datetime]::TryParse($tss, $null, [System.Globalization.DateTimeStyles]::RoundtripKind, [ref] $parsedValue)) {
                         Throw ("failed to parse scalar {0} as DateTime" -f $Node)
                     }
                     return $parsedValue


### PR DESCRIPTION
Strings that are tagged with ```!!timestamp``` will be converted to UTC time instead of local time. This change also uses ```RoundTripKind``` date time style.

Fixes: #69 