### PR TITLE
Check if StringQuotingEmitter is already added

### DIFF
--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -338,12 +338,14 @@ public class StringQuotingEmitter: ChainedEventEmitter {
 }
 "@
 
-$referenceList = @([YamlDotNet.Serialization.Serializer].Assembly.Location,[Text.RegularExpressions.Regex].Assembly.Location)
-if ($PSVersionTable.PSEdition -eq "Core") {
-    $referenceList += [IO.Directory]::GetFiles([IO.Path]::Combine($PSHOME, 'ref'), 'netstandard.dll', [IO.SearchOption]::TopDirectoryOnly)
-    Add-Type -TypeDefinition $stringQuotingEmitterSource -ReferencedAssemblies $referenceList -Language CSharp -CompilerOptions "-nowarn:1701"
-} else {
-    Add-Type -TypeDefinition $stringQuotingEmitterSource -ReferencedAssemblies $referenceList -Language CSharp
+if (!([System.Management.Automation.PSTypeName]'StringQuotingEmitter').Type) {
+    $referenceList = @([YamlDotNet.Serialization.Serializer].Assembly.Location,[Text.RegularExpressions.Regex].Assembly.Location)
+    if ($PSVersionTable.PSEdition -eq "Core") {
+        $referenceList += [IO.Directory]::GetFiles([IO.Path]::Combine($PSHOME, 'ref'), 'netstandard.dll', [IO.SearchOption]::TopDirectoryOnly)
+        Add-Type -TypeDefinition $stringQuotingEmitterSource -ReferencedAssemblies $referenceList -Language CSharp -CompilerOptions "-nowarn:1701"
+    } else {
+        Add-Type -TypeDefinition $stringQuotingEmitterSource -ReferencedAssemblies $referenceList -Language CSharp
+    }
 }
 
 function Get-Serializer {


### PR DESCRIPTION
Check if the ```StringQuotingEmitter``` already exists in the current namespace. Only attempt to add it if it does not.

Fixes: #68 