### PR TITLE
Allow reload of Module

### DIFF
--- a/Tests/powershell-yaml.Tests.ps1
+++ b/Tests/powershell-yaml.Tests.ps1
@@ -520,10 +520,4 @@ bools:
             }
         }
     }
-
-    Describe 'Module Manifest' {
-        Context 'Module is reloadable' {
-            Import-Module $modulePath -Force
-        }
-    }
 }

--- a/Tests/powershell-yaml.Tests.ps1
+++ b/Tests/powershell-yaml.Tests.ps1
@@ -520,4 +520,10 @@ bools:
             }
         }
     }
+
+    Describe 'Module Manifest' {
+        Context 'Module is reloadable' {
+            Import-Module $modulePath -Force
+        }
+    }
 }

--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -481,7 +481,11 @@ function ConvertTo-Yaml {
     }
 }
 
-New-Alias -Name cfy -Value ConvertFrom-Yaml
-New-Alias -Name cty -Value ConvertTo-Yaml
+if (-not (Get-Alias cfy -ErrorAction SilentlyContinue)) {
+    New-Alias -Name cfy -Value ConvertFrom-Yaml
+}
+if (-not (Get-Alias cty -ErrorAction SilentlyContinue)) {
+    New-Alias -Name cty -Value ConvertTo-Yaml
+}
 
 Export-ModuleMember -Function ConvertFrom-Yaml,ConvertTo-Yaml -Alias cfy,cty


### PR DESCRIPTION
In the past it was not possible to reload the module due to the try of overwrite existing alias.

```powershell
import-module powershell-yaml   
import-module powershell-yaml -force #failes
```
```
New-Alias : The alias is not allowed, because an alias with the name 'cfy' already exists.
At C:\GIT\powershell-yaml\powershell-yaml.psm1:484 char:1
+ New-Alias -Name cfy -Value ConvertFrom-Yaml
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ResourceExists: (cfy:String) [New-Alias], SessionStateException
    + FullyQualifiedErrorId : AliasAlreadyExists,Microsoft.PowerShell.Commands.NewAliasCommand
```

now this is possible again.


unfortunately, i was not able to develop a working test for this.