### PR TITLE
Fix conflict in hashtable

### DIFF
--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -217,7 +217,7 @@ function Convert-HashtableToDictionary {
         [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
         [hashtable]$Data
     )
-    foreach($i in $($data.Keys)) {
+    foreach($i in $($data.PSBase.Keys)) {
         $Data[$i] = Convert-PSObjectToGenericObject $Data[$i]
     }
     return $Data
@@ -228,7 +228,7 @@ function Convert-OrderedHashtableToDictionary {
         [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
         [System.Collections.Specialized.OrderedDictionary] $Data
     )
-    foreach ($i in $($data.Keys)) {
+    foreach ($i in $($data.PSBase.Keys)) {
         $Data[$i] = Convert-PSObjectToGenericObject $Data[$i]
     }
     return $Data


### PR DESCRIPTION
This change fixes a conflict between a hashtable key called "Keys" and the "Keys" property that exists as part of an IDictionary. This same fix will avoid any conflicts with other properties.

Fixes: https://github.com/cloudbase/powershell-yaml/issues/111

Thanks @SGStino!