### PR TITLE
Pin Assert to 0.9.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Assert -ErrorAction Stop
-          Install-Module Pester -ErrorAction Stop
+          Install-Module Assert -ErrorAction Stop -MaximumVersion 0.9.6 -Force
+          Install-Module Pester -ErrorAction Stop -Force
       - name: Run tests
         shell: pwsh
         run: |

--- a/Tests/powershell-yaml.Tests.ps1
+++ b/Tests/powershell-yaml.Tests.ps1
@@ -16,7 +16,7 @@
 # pinning this module to an exact version, 
 # because the options api will be merged with Assert-Equivalent
 # before release of 1.0.0
-Import-Module Assert -RequiredVersion 0.9.5
+Import-Module Assert -Version 0.9.6
 
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $moduleHome = Split-Path -Parent $here


### PR DESCRIPTION
This change pins the Assert powershell module to version 0.9.6.