### PR TITLE
Fix losing case sensitive keys

### DIFF
--- a/Tests/powershell-yaml.Tests.ps1
+++ b/Tests/powershell-yaml.Tests.ps1
@@ -669,4 +669,13 @@ int64: 9223372036854775807
             } | Should -Not -Throw
         }
     }
+
+    Describe 'Case insensitive keys in mappings' {
+        It 'should deserialize both keys' {
+            $yaml = '{"a": 1, "A": 2}'
+            $result = ConvertFrom-Yaml -Yaml $yaml
+            $result.a | Should -Be 1
+            $result.A | Should -Be 2
+        }
+    }
 }

--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -241,7 +241,7 @@ function Convert-YamlMappingToHashtable {
         [switch] $Ordered
     )
     PROCESS {
-        if ($Ordered) { $ret = [ordered]@{} } else { $ret = @{} }
+        if ($Ordered) { $ret = [System.Collections.Specialized.OrderedDictionary]::new() } else { $ret = [hashtable]::new() }
         foreach($i in $Node.Children.Keys) {
             $ret[$i.Value] = Convert-YamlDocumentToPSObject $Node.Children[$i] -Ordered:$Ordered
         }


### PR DESCRIPTION
Powershell is case aware but case insensitive for keys. By default if we create a hashtable @{}, keys are case insensitive. To force case sensitivity in hashtables, we need to call the C# constructor.