### PR TITLE
Add some links in `powershell-yaml.psd1` to associate the repository with the Powershell Gallery.

### DIFF
--- a/powershell-yaml.psd1
+++ b/powershell-yaml.psd1
@@ -30,6 +30,8 @@ ModuleVersion = '0.4.8'
 PrivateData = @{
     PSData = @{
         Prerelease = 'rc2'
+        LicenseUri   = 'https://github.com/cloudbase/powershell-yaml/blob/master/LICENSE'
+        ProjectUri   = 'https://github.com/cloudbase/powershell-yaml'
     }
 }
 


### PR DESCRIPTION
- Add some links in `powershell-yaml.psd1` to associate the github repository with the Powershell Gallery.
- When users visit the Powershell Gallery, it's easier to find the Github repository .