### PR TITLE
Switch from "Any" number style when parsing number

### DIFF
--- a/Tests/powershell-yaml.Tests.ps1
+++ b/Tests/powershell-yaml.Tests.ps1
@@ -203,6 +203,12 @@ wishlist:
     - product     : A Cool Book.
       quantity    : 1
       description : I love that Cool Book.
+      aStringTatLooksLikeAFloat: 55,34
+      aStringThatLooksLikeAnInt: 2018+
+      scientificNotationInt: 1e+3
+      scientificNotationBigInt: 1e+40
+      intWithTag: !!int "42"
+      scientificNotationIntWithTag: !!int "1e+3"
       price       : 55.34
 total: 4443.52
 int64: $([int64]::MaxValue)
@@ -244,7 +250,13 @@ bools:
                             product = "A Cool Book.";
                             quantity = 1;
                             description = "I love that Cool Book.";
-                            price = 55.34
+                            price = 55.34;
+                            aStringTatLooksLikeAFloat = "55,34"
+                            aStringThatLooksLikeAnInt = "2018+"
+                            scientificNotationInt = [int32]1000
+                            scientificNotationBigInt = [System.Numerics.BigInteger]::Parse("10000000000000000000000000000000000000000")
+                            intWithTag = 42
+                            scientificNotationIntWithTag = 1000
                         }
                     );
                     total = 4443.52;
@@ -289,6 +301,18 @@ bools:
                 $product['quantity'] | Should -Be $expectedProduct['quantity']
                 $product['description'] | Should -Be $expectedProduct['description']
                 $product['price'] | Should -Be $expectedProduct['price']
+                $product['aStringTatLooksLikeAFloat'] | Should -Be $expectedProduct['aStringTatLooksLikeAFloat']
+                $product['aStringTatLooksLikeAFloat'] | Should -BeOfType ([string])
+                $product['aStringThatLooksLikeAnInt'] | Should -Be $expectedProduct['aStringThatLooksLikeAnInt']
+                $product['aStringThatLooksLikeAnInt'] | Should -BeOfType ([string])
+                $product['scientificNotationInt'] | Should -Be $expectedProduct['scientificNotationInt']
+                $product['scientificNotationInt'] | Should -BeOfType ([int32])
+                $product['scientificNotationBigInt'] | Should -Be $expectedProduct['scientificNotationBigInt']
+                $product['scientificNotationBigInt'] | Should -BeOfType ([System.Numerics.BigInteger])
+                $product['intWithTag'] | Should -Be $expectedProduct['intWithTag']
+                $product['intWithTag'] | Should -BeOfType ([int32])
+                $product['scientificNotationIntWithTag'] | Should -Be $expectedProduct['scientificNotationIntWithTag']
+                $product['scientificNotationIntWithTag'] | Should -BeOfType ([int32])
                 $res['total'] | Should -Be $expected['total']
                 $res['note'] | Should -Be $expected['note']
 

--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -147,13 +147,13 @@ function Convert-ValueToProperType {
                                 $parsedValue = [Convert]::ToInt64($Node.Value.Substring(2), 16)
                             }
                             default {
-                                if (![System.Numerics.BigInteger]::TryParse($Node.Value, [Globalization.NumberStyles]::Any, [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)) {
+                                if (![System.Numerics.BigInteger]::TryParse($Node.Value, @([Globalization.NumberStyles]::Float, [Globalization.NumberStyles]::Integer), [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)) {
                                     Throw ("failed to parse scalar {0} as long" -f $Node)
                                 }
                             }
                         }
                     } else {
-                        if (![System.Numerics.BigInteger]::TryParse($Node.Value, [Globalization.NumberStyles]::Any, [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)) {
+                        if (![System.Numerics.BigInteger]::TryParse($Node.Value, @([Globalization.NumberStyles]::Float, [Globalization.NumberStyles]::Integer), [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)) {
                             Throw ("failed to parse scalar {0} as long" -f $Node)
                         }
                     }
@@ -179,7 +179,7 @@ function Convert-ValueToProperType {
                             }
                         }
                     }
-                    if (![double]::TryParse($Node.Value, [Globalization.NumberStyles]::Any, [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)) {
+                    if (![double]::TryParse($Node.Value, [Globalization.NumberStyles]::Float, [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)) {
                         Throw ("failed to parse scalar {0} as double" -f $Node)
                     }
                     return $parsedValue
@@ -205,7 +205,7 @@ function Convert-ValueToProperType {
             }
 
             $parsedValue = New-Object -TypeName ([System.Numerics.BigInteger].FullName)
-            $result = [System.Numerics.BigInteger]::TryParse($Node, [Globalization.NumberStyles]::Any, [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)
+            $result = [System.Numerics.BigInteger]::TryParse($Node, @([Globalization.NumberStyles]::Float, [Globalization.NumberStyles]::Integer), [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)
             if($result) {
                 $types = @([int], [long])
                 foreach($i in $types){
@@ -216,11 +216,10 @@ function Convert-ValueToProperType {
                 }
                 return $parsedValue
             }
-
             $types = @([double], [decimal])
             foreach($i in $types){
                 $parsedValue = New-Object -TypeName $i.FullName
-                $result = $i::TryParse($Node, [Globalization.NumberStyles]::Any, [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)
+                $result = $i::TryParse($Node, [Globalization.NumberStyles]::Float, [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)
                 if( $result ) {
                     return $parsedValue
                 }


### PR DESCRIPTION
Using [Globalization.NumberStyles]::Any when parsing numbers will parse even numbers that should be returned as strings, such as "2018+".

Explicitly using Integer and/or Float, will correclty parse integers and scientific notation integers such as 1e+3.

Fixes: #145