### PR TITLE
Use decimal as first option when parsing floats

### DIFF
--- a/Tests/powershell-yaml.Tests.ps1
+++ b/Tests/powershell-yaml.Tests.ps1
@@ -703,6 +703,7 @@ bools:
 bigInt: 99999999999999999999999999999999999
 int32: 2147483647
 int64: 9223372036854775807
+decimal: 3.10
 '@
         }
 
@@ -711,11 +712,19 @@ int64: 9223372036854775807
             $result.bigInt | Should -BeOfType System.Numerics.BigInteger
         }
 
+        It "Should round-trip decimals with trailing 0" {
+            $result = ConvertFrom-Yaml -Yaml $value
+            $result.decimal | Should -Be ([decimal]3.10)
+
+            ConvertTo-Yaml $result["decimal"] | Should -Be "3.10$([Environment]::NewLine)"
+        }
+
         It 'Should be of proper type and value' {
             $result = ConvertFrom-Yaml -Yaml $value
             $result.bigInt | Should -Be ([System.Numerics.BigInteger]::Parse("99999999999999999999999999999999999"))
             $result.int32 | Should -Be ([int32]2147483647)
             $result.int64 | Should -Be ([int64]9223372036854775807)
+            $result.decimal | Should -Be ([decimal]3.10)
         }
     }
 

--- a/powershell-yaml.psm1
+++ b/powershell-yaml.psm1
@@ -218,7 +218,7 @@ function Convert-ValueToProperType {
                 }
                 return $parsedValue
             }
-            $types = @([double], [decimal])
+            $types = @([decimal], [double])
             foreach($i in $types){
                 $parsedValue = New-Object -TypeName $i.FullName
                 $result = $i::TryParse($Node, [Globalization.NumberStyles]::Float, [Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)


### PR DESCRIPTION
Decimals offer much greater precission as opposed to double at the cost of performance. However, in most cases, precission is desirable.

Thanks @amis92 !

Fixes: #152 