### PR TITLE
Add some multi-document output support

### DIFF
--- a/powershell-yaml.psd1
+++ b/powershell-yaml.psd1
@@ -83,7 +83,7 @@ Description = 'Powershell module for serializing and deserializing YAML'
 PowerShellVersion = '5.0'
 
 # Functions to export from this module
-FunctionsToExport = "ConvertTo-Yaml","ConvertFrom-Yaml"
+FunctionsToExport = "ConvertTo-Yaml","ConvertFrom-Yaml","New-PowershellYamlMultiDocument"
 
 AliasesToExport = "cfy","cty"
 }


### PR DESCRIPTION
This change adds a new commandlet that returns a helper type which represents a multi-document yaml.

Usage:

```powershell
PS /> $multiDoc = New-PowershellYamlMultiDocument 
PS /> $multiDoc.Add(@{"hello"="world"})          
PS /> $multiDoc.Add(@{"goodbye"="world"})
PS /> cty $multiDoc
---
hello: world
---
goodbye: world
```

Fixes: #187

CC: @pacorreia